### PR TITLE
Fix theme issues found when porting from Wyam

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Replace or copy any of these Razor partials in your `input` folder to override s
 - `/_post-footer.cshtml`: Displays content at the bottom of a post (for example, a comments section).
 - `/_sidebar.cshtml`: Additional content for the sidebar on the main index page (ignored if you provide your own index page).
 - `/_footer.cshtml`: The footer at the bottom of all pages.
-- `/_scripts`: Additional scripts or other content at the bottom of the page.
+- `/_scripts.cshtml`: Additional scripts or other content at the bottom of the page.
 
 # Sections
 

--- a/input/_header.cshtml
+++ b/input/_header.cshtml
@@ -5,15 +5,17 @@
         backgroundImage = $"background-image: url(\"{Context.GetLink(Document.GetString(WebKeys.Image))}\")";
     }
     string description = Document.WithoutSettings().GetString("Lead") ?? Document.WithoutSettings().GetString(WebKeys.Description);
+    bool isPost = Document.GetBool("IsPost");
+    string headerTitle = isPost ? Document.GetString("Title") : Document.GetString("SiteTitle");
 }
 <header class="masthead" style="@backgroundImage">
   <div class="overlay"></div>
   <div class="container">
     <div class="row">
       <div class="col-md-12">
-        <div class="@(Document.GetBool("IsPost") ? "post-heading" : "site-heading")">
+        <div class="@(@isPost ? "post-heading" : "site-heading")">
           <h1>
-            @Document.GetString("Title")
+            @headerTitle
             @if (Document.GetInt(Keys.Index) > 1)
             {
               <small>(Page @Document.GetString(Keys.Index))</small>
@@ -23,7 +25,7 @@
           {
             <h2 class="subheading">@description</h2>
           }
-          @if (Document.GetBool("IsPost"))
+          @if (@isPost)
           {
               // This is a blog post so show extra data
               <div class="meta">Published on @Document.GetDateTime(WebKeys.Published).ToLongDateString()</div>

--- a/input/_header.cshtml
+++ b/input/_header.cshtml
@@ -5,17 +5,17 @@
         backgroundImage = $"background-image: url(\"{Context.GetLink(Document.GetString(WebKeys.Image))}\")";
     }
     string description = Document.WithoutSettings().GetString("Lead") ?? Document.WithoutSettings().GetString(WebKeys.Description);
-    bool isPost = Document.GetBool("IsPost");
-    string headerTitle = isPost ? Document.GetString("Title") : Document.GetString("SiteTitle");
+    string title = Document.GetString("Title") ?? Document.GetString("SiteTitle");
+    bool isPost = Document.GetBool("IsPost") && title != "Tags" && title != "Archive";
 }
 <header class="masthead" style="@backgroundImage">
   <div class="overlay"></div>
   <div class="container">
     <div class="row">
       <div class="col-md-12">
-        <div class="@(@isPost ? "post-heading" : "site-heading")">
+        <div class="@(isPost ? "post-heading" : "site-heading")">
           <h1>
-            @headerTitle
+            @title
             @if (Document.GetInt(Keys.Index) > 1)
             {
               <small>(Page @Document.GetString(Keys.Index))</small>
@@ -25,7 +25,7 @@
           {
             <h2 class="subheading">@description</h2>
           }
-          @if (@isPost)
+          @if (isPost)
           {
               // This is a blog post so show extra data
               <div class="meta">Published on @Document.GetDateTime(WebKeys.Published).ToLongDateString()</div>

--- a/input/_layout.cshtml
+++ b/input/_layout.cshtml
@@ -27,8 +27,8 @@
     }
   }
   
-  <meta name="application-name" content="@Context.GetString(WebKeys.Title)" />
-  <meta name="msapplication-tooltip" content="@Context.GetString(WebKeys.Title)" />
+  <meta name="application-name" content="@Document.GetString("SiteTitle")" />
+  <meta name="msapplication-tooltip" content="@Document.GetString("SiteTitle")" />
   <meta name="msapplication-starturl" content="@Context.GetLink("/")" />
 
   @* TODO: More social graph meta tags *@

--- a/input/_layout.cshtml
+++ b/input/_layout.cshtml
@@ -91,14 +91,14 @@
 
   <!-- Footer -->  
   @RenderSectionOrPartial("Footer", "_footer")
-  
-  @Html.Partial("_scripts")
-
-  @RenderSection("Scripts", false)
 
   <!-- Bootstrap core JavaScript -->
   <script src="@Context.GetLink("/vendor/jquery/jquery.min.js")"></script>
   <script src="@Context.GetLink("/vendor/bootstrap/js/bootstrap.bundle.min.js")"></script>
+
+  @Html.Partial("_scripts")
+
+  @RenderSection("Scripts", false)
 
   <!-- Custom scripts for this template -->
   <script src="@Context.GetLink("/js/clean-blog.js")"></script>


### PR DESCRIPTION
_layout.cshtml

- Use `SiteTitle` in the `application-name` and `msapplication-tooltip` metadata tags
- Move `_scripts` partial below vendor scripts so they can use jQuery

_header.cshtml

- Render heading title as `Title` or `SiteTitle` based on `IsPost`

README.md

- Minor consistency issue with naming of partials