### PR TITLE
Update PostSources to support one level of dir in controller by default

### DIFF
--- a/settings.yml
+++ b/settings.yml
@@ -8,6 +8,6 @@ PageTitle: |
     return string.IsNullOrWhiteSpace(siteTitle) ? title : (string.IsNullOrWhiteSpace(title) ? siteTitle : $"{siteTitle} - {title}");
   }
 Copyright: => $"Copyright © {DateTime.Now.Year}"
-PostSources: posts/*
+PostSources: posts/**/*
 IsPost: => Outputs.FilterSources(Context.GetString("PostSources")).ContainsById(Document)
 Layout: /_layout.cshtml


### PR DESCRIPTION
This is a most commonly used setting. It should be enabled by default for convenience if we may.

to support post URLs like,

support `/posts/year`, for example,

    https://blog.corp.com/posts/2011/post-title.html

support `/posts/category`, for example,

    https://blog.corp.com/posts/algorithm/algo-post-title.html

Otherwise, we have to fork theme submodule to make this small change to support mentioned use cases of URL.

Test of the template,

![image](https://user-images.githubusercontent.com/7858031/141360262-24da03cc-7b64-4e54-85b0-5511316c460d.png)


To the contributors, owners and maintainers, thank you for this awesome project  :)