### PR TITLE
Format dates according to settings

### DIFF
--- a/input/_header.cshtml
+++ b/input/_header.cshtml
@@ -28,7 +28,7 @@
           @if (isPost)
           {
               // This is a blog post so show extra data
-              <div class="meta">Published on @Document.GetDateTime(WebKeys.Published).ToLongDateString()</div>
+              <div class="meta">Published on @Document.GetDateTime(WebKeys.Published).ToLongDateString(Context)</div>
               @if (Document.ContainsKey("Tags"))
               {
                 <div class="mt-3">

--- a/input/_post.cshtml
+++ b/input/_post.cshtml
@@ -10,7 +10,7 @@
     {
         <div class="post-subtitle">@Model.GetString("Lead")</div>
     }
-    <p class="post-meta">Published on @Model.GetDateTime(WebKeys.Published).ToLongDateString()</p>
+    <p class="post-meta">Published on @Model.GetDateTime(WebKeys.Published).ToLongDateString(Context)</p>
     @if (!string.IsNullOrEmpty(excerpt))
     {
         @Html.Raw(excerpt)

--- a/input/posts.cshtml
+++ b/input/posts.cshtml
@@ -17,7 +17,7 @@ ArchiveOrderDescending: true
             {
                 <div class="post-subtitle">@post.GetString("Lead")</div>
             }
-            <p class="post-meta">Published on @post.GetDateTime(WebKeys.Published).ToLongDateString()</p>
+            <p class="post-meta">Published on @post.GetDateTime(WebKeys.Published).ToLongDateString(Context)</p>
         </div>
     }
 }


### PR DESCRIPTION
This PR fixes the three instances in which `DateTime.ToLongDateString()` is called instead of `DateTimeCultureExtensions.ToLongDateString(IExecutionContext)`, thus ignoring any `DateTimeDisplayCulture` setting.

I didn't even open an issue for this since it is a rather trivial bug with a rather trivial fix.
