### PR TITLE
Prettier blockquotes

### DIFF
--- a/input/scss/_global.scss
+++ b/input/scss/_global.scss
@@ -33,8 +33,10 @@ a {
 }
 
 blockquote {
-  font-style: italic;
-  color: $gray-600;
+  background-color: $gray-200;
+  padding: 1rem 1rem 1rem 1.25rem;
+  margin-left: 2rem;
+  border-left: 0.25rem dashed $gray-800;
 }
 
 .section-heading {

--- a/input/scss/_global.scss
+++ b/input/scss/_global.scss
@@ -34,9 +34,8 @@ a {
 
 blockquote {
   background-color: $gray-200;
-  padding: 1rem 1rem 1rem 1.25rem;
-  margin-left: 2rem;
-  border-left: 0.25rem dashed $gray-800;
+  padding: 1rem 1rem 1rem 3rem;
+  border-left: 1rem solid $gray-500;
 
   & > :first-child { margin-top: 0; }
   & > :last-child { margin-bottom: 0; }

--- a/input/scss/_global.scss
+++ b/input/scss/_global.scss
@@ -37,6 +37,9 @@ blockquote {
   padding: 1rem 1rem 1rem 1.25rem;
   margin-left: 2rem;
   border-left: 0.25rem dashed $gray-800;
+
+  & > :first-child { margin-top: 0; }
+  & > :last-child { margin-bottom: 0; }
 }
 
 .section-heading {


### PR DESCRIPTION
This PR makes blockquotes look like blockquotes, as opposed to mere pieces of italicized text.

This is how a blockquote will look like after merging this PR:

![blockquote](https://user-images.githubusercontent.com/139223/197311285-d3cda467-8371-4684-9dc5-8e130abd4131.png)

For reference, this is the Markdown source for the blockquote in the image above:

```text
  > Nullam in ipsum eros. Aenean porta mi vitae justo hendrerit, eget pharetra erat tempus.
  >
  > _&mdash; Loremus de Ipsumis, "Dolor sit? Amet!", ch. 19_
```
