### PR TITLE
Simplify Image Attribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,8 +170,7 @@ These can be set in front matter, a sidecar file, etc. (in addition to any of St
 - `Tags`: Tags for a blog post.
 - `Published`: The date a page or post was published.
 - `Image`: Path to an image for the page or post.
-- `ImageAttribution`: Raw HTML of copyright attribution for the image.
-- `ImageAttributionMarkdown`: Markdown of copyright attribution for the image (`ImageAttribution` will be used instead of this if it's defined, so make sure only `ImageAttributionMarkdown` is defined if you want to use it).
+- `ImageAttribution`: Markdown of copyright attribution for the image.
 - `ShowInNavbar`: Set to `false` to hide a static page in the top navigation bar.
 - `IsPost`: Set to `false` to exclude the file from the set of posts. This will also disable post styling like displaying tags in the header.
 - `IsPage`: Set to `false` to exclude the file from the set of static pages. This will also disable navigation bar linking.

--- a/input/_header.cshtml
+++ b/input/_header.cshtml
@@ -17,8 +17,6 @@
   bool isPage = Document.GetBool("IsPage");
   var imageAttribution = Document.GetString("ImageAttribution", string.Empty);
   var hasImageAttribution = !string.IsNullOrEmpty(imageAttribution);
-  var imageAttributionMarkdown = Document.GetString("ImageAttributionMarkdown", string.Empty);
-  var hasImageAttributionMarkdown = !string.IsNullOrEmpty(imageAttributionMarkdown);
 }
 <header class="@mastheadClass" style="@mastheadStyle">
   <div class="container position-relative">
@@ -58,10 +56,6 @@
   </div>
   @if (hasImageAttribution)
   {
-    <div class="image-attribution badge text-bg-secondary rounded-pill">@Html.Raw(imageAttribution)</div>
-  }
-  else if (hasImageAttributionMarkdown)
-  {
-    <div class="image-attribution badge text-bg-secondary rounded-pill"><?# Markdown ?>@Html.Raw(imageAttributionMarkdown)<?#/ Markdown ?></div>
+    <div class="image-attribution badge text-bg-secondary rounded-pill"><?# Markdown ?>@Html.Raw(imageAttribution)<?#/ Markdown ?></div>
   }
 </header>


### PR DESCRIPTION
Support both Markdown and RawHtml in one variable: `imageAttribution`.

Test output,

![image](https://user-images.githubusercontent.com/7858031/210271123-a0505e76-c7fa-49b8-87c7-e6c464378769.png)


ref commit 8543531ff