### PR TITLE
Use absolute URI for og:image

### DIFF
--- a/input/_layout.cshtml
+++ b/input/_layout.cshtml
@@ -41,7 +41,7 @@
   <meta property="og:title" content='@Document.GetString("PageTitle")' />
   @if (Document.ContainsKey(WebKeys.Image))
   {
-    <meta property="og:image" content='@Context.GetLink(Document.GetString(WebKeys.Image))' />
+    <meta property="og:image" content='@Context.GetLink(Document.GetString(WebKeys.Image), true)' />
   }
   <meta property="og:type" content="website" />
   <meta property="og:url" content='@Document.GetLink(true)' />


### PR DESCRIPTION
There are many parsers who can't parse relative open graph URIs so it's better to use absolute URI's here. #40